### PR TITLE
[feat] Uses chiselled packages

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -36,4 +36,5 @@ parts:
   packages:
     plugin: nil
     stage-packages:
-      - ca-certificates
+      - ca-certificates_data
+      - libc6_libs


### PR DESCRIPTION
# Description

Uses chisel to reduce the image size. It is finally smaller than the upstream image:

```bash
guillaume@potiron:~/PycharmProjects/vault-rock/tests$ docker images
REPOSITORY        TAG       IMAGE ID       CREATED          SIZE
vault             1.14.3    a76f583108fb   16 minutes ago   375MB
hashicorp/vault   1.14.3    85e930d819c1   2 weeks ago      378MB
```

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
