### PR TITLE
strip go binaries to reduce OCI size

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -22,10 +22,14 @@ parts:
     source: https://github.com/hashicorp/vault.git
     source-tag: v1.15.0
     source-type: git
+    source-depth: 1
     stage:
       - bin/vault
     build-snaps:
       - go/1.21/stable
+    override-build: |
+      craftctl default
+      strip -s $CRAFT_PART_INSTALL/bin/*
 
   default-config:
     plugin: dump


### PR DESCRIPTION
The go binaries produced by the build can be stripped which should reduce the overall size of the OCI produced:

$ docker images
REPOSITORY   TAG       IMAGE ID       CREATED              SIZE
vault        1.15.0    6f62316c5777   About a minute ago   284MB

This method is used in the vault snap to achieve the same optimisation.

Set source-depth to 1 to reduce the time taken to clone the upstream repo (it has alot of history).
