### PR TITLE
chore: Runs workflow on PR

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,12 @@
 name: Main
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
+    branches:
+      - main
   schedule:
     - cron: '0 8 * * 2'
 


### PR DESCRIPTION
# Description

[This PR](https://github.com/canonical/vault-rock/pull/9) made me realise that workflows don't run if the change comes from a fork of the project. This PR makes it so that workflows run on PR's and pushes to main.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
