### PR TITLE
feat: Bumps to Vault 1.15.3

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: vault
 base: bare
 build-base: ubuntu@22.04
-version: "1.15.2"
+version: "1.15.3"
 summary: A ROCK container image for Vault
 description: |
   A ROCK container image for Vault, a tool for secrets management, encryption as a service, and privileged access management.
@@ -21,7 +21,7 @@ parts:
   vault:
     plugin: go
     source: https://github.com/hashicorp/vault.git
-    source-tag: v1.15.2
+    source-tag: v1.15.3
     source-type: git
     source-depth: 1
     stage:


### PR DESCRIPTION
# Description

Vault 1.15.3 is now available upstream and this PR bumps the rock to build Vault from this tag.

## Reference
- https://github.com/hashicorp/vault

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
