### PR TITLE
chore: Specifies permission in workflow file

### DIFF
--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -4,9 +4,10 @@ on:
   workflow_call:
 
 jobs:
-
   scan:
     runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,10 +41,10 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "ghcr.io/canonical/${{env.image_name}}:${{env.version}}"
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          format: "sarif"
+          output: "trivy-results.sarif"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
# Description

It looks like workflows lost their read/write permissions and now only got read permissions. Here we specify the required permission in the workflow file itself as a workaround. Note that I'm not certain this workaround works at this point. 

![image](https://github.com/canonical/vault-rock/assets/18486508/5341e463-8729-4e53-aa77-0e41fb381730)

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
