### PR TITLE
fix: Fixes issue with pack

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/checkout@v4
       - uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
+        with:
+          revision: latest/candidate
       - uses: actions/upload-artifact@v3
         with:
           name: rock

--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
         with:
-          revision: latest/candidate
+          revision: 1481
       - uses: actions/upload-artifact@v3
         with:
           name: rock


### PR DESCRIPTION
# Description

There's an issue with rockcraft 1.1.0 preventing rocks with chiseled packages from packing. Here we wanted to validate that Rockcraft 1.1.1 fixes this issue. Do not merge this PR, I want to avoid having to maintain snap revisions in all of our Rock's CI's.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
