### PR TITLE
chore: run CI workflow on protected branches

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  main:
+  pr-lint:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,12 +1,14 @@
-name: Main
+name: Protected Branches
 
 on:
   pull_request:
     branches:
       - main
+      - release-*
   push:
     branches:
       - main
+      - release-*
   schedule:
     - cron: '0 8 * * 2'
 
@@ -28,6 +30,6 @@ jobs:
     uses: ./.github/workflows/integration-tests.yaml
 
   publish:
-    if: github.ref_name == 'main'
+    if: github.ref_name == 'main' || startsWith(github.ref_name, 'release-')
     needs: [scan, build, integration-tests]
     uses: ./.github/workflows/publish-rock.yaml


### PR DESCRIPTION
# Description

Currently the CI only runs on the `main` branch. As Vault is now available for `1.16`, we will want to create a release branch for `1.15` and have `main` track `1.16`. Prior to creating a new `release-1.15` branch and a `release-*` branch protection rule, we need to ensure that GitHub workflows run on those protected branches.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
