### PR TITLE
chore: update license to BUSL-1.1

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -5,7 +5,7 @@ version: "1.16.1"
 summary: A ROCK container image for Vault
 description: |
   A ROCK container image for Vault, a tool for secrets management, encryption as a service, and privileged access management.
-license: Apache-2.0
+license: busl-1.1
 platforms:
   amd64:
   arm64:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -5,7 +5,7 @@ version: "1.16.1"
 summary: A ROCK container image for Vault
 description: |
   A ROCK container image for Vault, a tool for secrets management, encryption as a service, and privileged access management.
-license: busl-1.1
+license: BUSL-1.1
 platforms:
   amd64:
   arm64:


### PR DESCRIPTION
# Description

The upstream Vault is now licensed under `BUSL-1.1`, and here we make the necessary changes for the rock to be distributed under this same license.

Fixes #88 

## Rationale


> Although the BCL is not a FOSS license, it works like one in two important ways: (1) it allows for derivative works (our snap), and (2) it applies to those derivative works.
> 
> The snap is therefore under the same BCL as the software it encapsulates BCL'd software.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
