### PR TITLE
chore: use ubuntu 24.04 build base

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: vault
 base: bare
-build-base: ubuntu@22.04
+build-base: ubuntu@24.04
 version: "1.16.2"
 summary: A ROCK container image for Vault
 description: |
@@ -43,3 +43,4 @@ parts:
     stage-packages:
       - ca-certificates_data
       - libc6_libs
+      - base-files_lib


### PR DESCRIPTION
# Description

Bump the build base to Ubuntu 24.04. Here we also need to include the base-files_lib slice because starting Ubuntu 24.04, the 'base-files' package provides "bin" as a symlink to "usr/bin".

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
