### PR TITLE
chore: use skopeo from rockcraft

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -10,9 +10,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install skopeo
+      - name: Install rockcraft
         run: |
-          sudo snap install --devmode --channel edge skopeo
+          sudo snap install rockcraft --classic --channel edge
 
       - name: Install yq
         run: |
@@ -29,7 +29,7 @@ jobs:
           version="$(yq '.version' rockcraft.yaml)"
           echo "version=${version}" >> $GITHUB_ENV
           rock_file=$(ls *.rock | tail -n 1)
-          sudo skopeo \
+          sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${rock_file}" \

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -17,9 +17,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install skopeo
+      - name: Install rockcraft
         run: |
-          sudo snap install --devmode --channel edge skopeo
+          sudo snap install rockcraft --classic --channel edge
       - uses: actions/download-artifact@v4
         with:
           name: rock
@@ -29,7 +29,7 @@ jobs:
           image_name="$(yq '.name' rockcraft.yaml)"
           version="$(yq '.version' rockcraft.yaml)"
           rock_file=$(ls *.rock | tail -n 1)
-          sudo skopeo \
+          sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${rock_file}" \

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -10,9 +10,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install skopeo
+      - name: Install rockcraft
         run: |
-          sudo snap install --devmode --channel edge skopeo
+          sudo snap install rockcraft --classic --channel edge
 
       - name: Install yq
         run: |
@@ -29,7 +29,7 @@ jobs:
           version="$(yq '.version' rockcraft.yaml)"
           echo "version=${version}" >> $GITHUB_ENV
           rock_file=$(ls *.rock | tail -n 1)
-          sudo skopeo \
+          sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${rock_file}" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,6 @@
 ```bash
 rockcraft pack -v
 vault_version=$(yq '.version' rockcraft.yaml)
-sudo skopeo --insecure-policy copy oci-archive:vault_${vault_version}_amd64.rock docker-daemon:vault:${vault_version}
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:vault_${vault_version}_amd64.rock docker-daemon:vault:${vault_version}
 docker run vault:${vault_version}
 ```


### PR DESCRIPTION
# Description

Use skopeo from rockcraft. This addresses an issue where we were not able to copy the built OCI image to docker images. The skopeo version in the snap dates from 2019 (v1.13.3) as the one in rockcraft is more recent (v1.14.2)

## Logs

```
time="2024-06-14T18:40:29Z" level=fatal msg="writing blob: io: read/write on closed pipe"
```

## Reference

- https://github.com/canonical/rockcraft/pull/477

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
