### PR TITLE
chore: bump workload to 1.18.5

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: vault
 base: bare
 build-base: ubuntu@24.04
-version: "1.18.3"
+version: "1.18.5"
 summary: A ROCK container image for Vault
 description: |
   A ROCK container image for Vault, a tool for secrets management, encryption as a service, and privileged access management.
@@ -36,7 +36,7 @@ parts:
       - vault
       - ui
     source: https://github.com/hashicorp/vault.git
-    source-tag: v1.18.3
+    source-tag: v1.18.5
     source-type: git
     source-depth: 1
     stage:


### PR DESCRIPTION
# Description

Bump workload to v1.18.5

## Reference
- https://github.com/hashicorp/vault/releases/tag/v1.18.5

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
